### PR TITLE
Bugfix to allow non-local SQL database creation

### DIFF
--- a/lib/WeBWorK/Install/Database.pm
+++ b/lib/WeBWorK/Install/Database.pm
@@ -65,8 +65,8 @@ sub get_dsn {
 ############################################################
 
 sub create_database {
-    my ( $dsn, $root_pw, $ww_db, $ww_user, $ww_pw ) = @_;
-    my $dbh = DBI->connect( 'DBI:mysql:database=mysql', 'root', $root_pw );
+    my ( $server, $root_pw, $ww_db, $ww_user, $ww_pw ) = @_;
+    my $dbh = DBI->connect( 'DBI:mysql:database=mysql;host=$server', 'root', $root_pw );
     print_and_log("Connected to mysql as root...");
     $dbh->do("CREATE DATABASE IF NOT EXISTS $ww_db")
       or die "Could not create $ww_db database: $!\n";

--- a/lib/WeBWorK/Install/Database.pm
+++ b/lib/WeBWorK/Install/Database.pm
@@ -66,7 +66,7 @@ sub get_dsn {
 
 sub create_database {
     my ( $server, $root_pw, $ww_db, $ww_user, $ww_pw ) = @_;
-    my $dbh = DBI->connect( 'DBI:mysql:database=mysql;host=$server', 'root', $root_pw );
+    my $dbh = DBI->connect( "dbi:mysql:database=mysql;host=$server", 'root', $root_pw );
     print_and_log("Connected to mysql as root...");
     $dbh->do("CREATE DATABASE IF NOT EXISTS $ww_db")
       or die "Could not create $ww_db database: $!\n";


### PR DESCRIPTION
The create_database function omitted the host=$server component which resulted in the create_database always running on localhost.